### PR TITLE
Fix backend bug where saving round shuffles rounds in RoundList

### DIFF
--- a/Backend/api/routes/users.js
+++ b/Backend/api/routes/users.js
@@ -208,11 +208,12 @@ server.get("/rounds/:id", utilities.protected, async (req, res) => {
       )
       .from("Games as g")
       .leftJoin("Rounds as r", "r.game_id", "g.id")
-      .where("g.id", "=", id);
+      .where("g.id", "=", id)
+      .orderBy("roundId");
 
     res.status(200).json(rounds);
   } catch (err) {
-    console.log("err.message get rounds: ", newGame);
+    console.log("err.message get rounds: ", err.message);
     res.status(500).json({ message: "Problem getting rounds" });
   }
 });

--- a/Frontend/trivializer/src/components/RoundsList.js
+++ b/Frontend/trivializer/src/components/RoundsList.js
@@ -21,7 +21,8 @@ class RoundsList extends Component {
       newRoundOuterHeight: null,
       newRoundWidth: null,
       newRoundHeight: null,
-      roundLimit: 3
+      roundLimit: 3,
+      rounds: []
     };
   }
 


### PR DESCRIPTION
# Description
Change backend endpoint where using Save Round in Rounds causes the saved round to move to the end of the rounds list. 

Fixes # None

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change status
- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Altered several rounds and rounds no longer move to the end of the list. All changes persist

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
